### PR TITLE
Fixed stylus eraser being rejected by palm rejection

### DIFF
--- a/services/inputflinger/InputReader.cpp
+++ b/services/inputflinger/InputReader.cpp
@@ -6167,7 +6167,8 @@ nsecs_t TouchInputMapper::mLastStylusTime = 0;
 
 bool TouchInputMapper::rejectPalm(nsecs_t when) {
     return (when - mLastStylusTime < mConfig.stylusPalmRejectionTime) &&
-        mPointerSimple.currentProperties.toolType != AMOTION_EVENT_TOOL_TYPE_STYLUS;
+        mPointerSimple.currentProperties.toolType != AMOTION_EVENT_TOOL_TYPE_STYLUS &&
+        mPointerSimple.currentProperties.toolType != AMOTION_EVENT_TOOL_TYPE_ERASER;
 }
 
 void TouchInputMapper::cancelTouch(nsecs_t when) {


### PR DESCRIPTION
The stylus eraser appeared not to work, i.e. Android did not respond to
input from the eraser. It turned out that all input except stylus input
is rejected when palm rejection is activated. The problem was that the
eraser itself activates palm rejection when it hovers. The solution is
to allow the eraser during palm rejection. This solution makes sense
because the eraser input works in the exact same way as normal stylus
input.

Change-Id: I9c7451112ce7dbca14a1e1694eedca2d4ed041a1
