### PR TITLE
Fix xxxhdpi 3072 heap sizes

### DIFF
--- a/build/phone-xxxhdpi-3072-dalvik-heap.mk
+++ b/build/phone-xxxhdpi-3072-dalvik-heap.mk
@@ -18,8 +18,8 @@
 
 PRODUCT_PROPERTY_OVERRIDES += \
     dalvik.vm.heapstartsize=8m \
-    dalvik.vm.heapgrowthlimit=384m \
-    dalvik.vm.heapsize=1024m \
+    dalvik.vm.heapgrowthlimit=288m \
+    dalvik.vm.heapsize=768m \
     dalvik.vm.heaptargetutilization=0.75 \
     dalvik.vm.heapminfree=2m \
     dalvik.vm.heapmaxfree=8m


### PR DESCRIPTION
Bootloops on shamu with current values

Fix for 94774ac01d1953bcc7a70a7018267ee34793d3f7

Change-Id: Iade253bd8bc5074486d2d69bb9c738844615b08d
